### PR TITLE
Remove unnecessary admin field

### DIFF
--- a/q_admin/admin.py
+++ b/q_admin/admin.py
@@ -10,7 +10,7 @@ class QuestionLogAdmin(admin.ModelAdmin):
     def formatted_date_attempted(self, obj):
         return localtime(obj.date_attempted).date()
 
-    readonly_fields = ("formatted_date_attempted", "formatted_last_reviewed")
+    readonly_fields = ("formatted_date_attempted",)
 
 
 # Commenting out QuestionAdmin temporarily to resolve migration issues


### PR DESCRIPTION
## Summary
- clean up admin by removing `formatted_last_reviewed` from `readonly_fields`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684709db5d0883238b48a7b7979a61ac