### PR TITLE
Clarify import API status and expand tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project is a full-stack application for managing programming interview ques
 - **Backend:**
   - Built with Django and Django REST Framework (DRF).
   - Provides a RESTful API for managing questions, tags, and user activity logs.
-  - Supports importing question logs from external coding platforms (e.g., Codewars).
+  - Planned support for importing question logs from external coding platforms (see `docs/import_api_design.md`).
   - Includes robust testing, data seeding, and admin customization.
   - See `docs/backend_design.md` and `docs/import_api_design.md` for detailed backend and API design.
 
@@ -15,7 +15,7 @@ This project is a full-stack application for managing programming interview ques
   - Built with React and Material UI, using Vite for fast development.
   - Allows users to view, add, edit, and delete questions, tags, and logs.
   - Supports tag management and question filtering.
-  - Provides a user-friendly interface for importing activity from supported coding platforms.
+  - A user-friendly import interface is planned once backend support is implemented.
 
 ## Getting Started
 

--- a/docs/features/import_api_design.md
+++ b/docs/features/import_api_design.md
@@ -1,5 +1,7 @@
 # Import API Design Overview
 
+*This design is aspirational—the actual import API and its background task infrastructure have not been implemented yet.*
+
 ## Functional Requirements
 
 1. **Import Question Logs from Coding Platforms**

--- a/docs/future_concerns.md
+++ b/docs/future_concerns.md
@@ -12,9 +12,10 @@ This document outlines potential areas for improvement, future enhancements, and
 - Standardize error feedback in the frontend (e.g., toast notifications, inline messages) for a more user-friendly experience.
 - Consider adding onboarding flows or help tips for new users, especially for the import feature.
 
-### 3. API Rate Limiting & Background Processing
-- Implement rate limiting or background jobs for import operations to avoid timeouts and external API bans.
-- Consider making imports asynchronous if they may be slow or unreliable.
+### 3. Import API & Background Processing
+- Build the import API endpoints for pulling logs from coding platforms (this feature is not implemented yet).
+- Implement background job infrastructure so long-running imports can run asynchronously.
+- Add rate limiting to avoid timeouts and external API bans.
 
 ### 4. Frontend State Management
 - If the app grows, introduce a global state manager (e.g., Redux, Zustand, or React Context) for better scalability and maintainability.
@@ -44,3 +45,5 @@ This document outlines potential areas for improvement, future enhancements, and
 ---
 
 Addressing these areas will help ensure the application remains robust, scalable, and user-friendly as it evolves.
+
+See [prioritized_tasks.md](prioritized_tasks.md) for a proposed task breakdown and relative priorities.

--- a/docs/prioritized_tasks.md
+++ b/docs/prioritized_tasks.md
@@ -1,0 +1,36 @@
+# Prioritized Task Breakdown
+
+This document organizes the ideas from `future_concerns.md` into actionable tasks with a rough priority order.
+
+## Priority 1 – Core Foundations
+- **User Authentication & Authorization**
+  - Add backend user accounts and authentication (JWT or session based).
+  - Scope questions and logs to the authenticated user.
+  - Implement login/registration flows in the frontend.
+- **Import API Implementation & Background Jobs**
+  - Build the import API endpoints for supported coding platforms.
+  - Create a background task system so imports can run asynchronously.
+  - Add rate limiting to keep upstream services happy.
+- **Frontend Test Coverage**
+  - Set up Jest/React Testing Library for component tests.
+  - Add end‑to‑end tests (Cypress or Playwright).
+
+## Priority 2 – Usability & Documentation
+- **Error Feedback & Onboarding**
+  - Standardize toast/inline error messages across the UI.
+  - Provide onboarding or help tips for the import feature.
+- **State Management & Accessibility**
+  - Evaluate a global state manager (Redux, Zustand, or Context) if the app grows.
+  - Audit UI components for ARIA labels and keyboard navigation.
+- **API Documentation**
+  - Publish OpenAPI/Swagger docs for the backend.
+- **Deployment & CI/CD**
+  - Document or automate deployment steps (Docker, GitHub Actions).
+- **Data Privacy**
+  - Clarify how user data is stored and deleted; draft a privacy policy.
+
+## Priority 3 – Future Enhancements
+- Support more coding platforms in the import API.
+- Add advanced filtering, search, and analytics in the frontend.
+- Improve admin and moderation tools for managing questions and logs.
+- Enhance user profile and progress tracking features.


### PR DESCRIPTION
## Summary
- clarify that the import API is not implemented yet
- break out import API & background job tasks in prioritized_tasks
- update future_concerns with the same language
- adjust README to mention planned import feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b442fdfc8323817caf95cde106ed