### PR TITLE
Add drf-spectacular API docs

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -40,6 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "backend.core",
     "backend.q_admin",
+    "drf_spectacular",
     "corsheaders",  # Added for CORS
 ]
 
@@ -161,3 +162,13 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
 ]
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "Interview Questions API",
+    "DESCRIPTION": "API documentation for the Interview Questions app",
+    "VERSION": "1.0.0",
+}

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,5 +1,8 @@
 from django.urls import path, include
+from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
 urlpatterns = [
+    path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema"), name="docs"),
     path("api/", include("backend.core.urls")),
 ]

--- a/docs/api_documentation.md
+++ b/docs/api_documentation.md
@@ -1,0 +1,22 @@
+# API Documentation
+
+This project uses **drf-spectacular** to generate OpenAPI documentation.
+
+## Accessing the Docs
+
+- **Schema (JSON):** `http://localhost:8000/api/schema/`
+- **Swagger UI:** `http://localhost:8000/api/docs/`
+
+Run the Django development server and visit the above URLs in your browser to view the OpenAPI schema or interactive UI.
+
+## Updating the Schema
+
+1. Ensure new endpoints include proper DRF serializer and view definitions.
+2. The schema is generated dynamically at runtime. No manual steps are required after updating code.
+3. If you change global settings, update `SPECTACULAR_SETTINGS` in `backend/settings.py`.
+
+To install missing dependencies, run:
+
+```bash
+pip install -r requirements.txt
+```

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 django
 djangorestframework
 requests
+drf-spectacular

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.8.1
 Django==5.2.1
 djangorestframework==3.16.0
 requests==2.32.3
+drf-spectacular==0.27.1


### PR DESCRIPTION
## Summary
- install drf-spectacular
- configure schema generation in Django settings
- expose `/api/schema/` and `/api/docs/` routes
- document OpenAPI usage in `docs/api_documentation.md`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement asgiref==3.8.1)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b7f9cb3c8323b0f84c9458f8932b