### PR TITLE
Add cyclomatic complexity check

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 exclude = venv, __pycache__
 max-line-length = 88
+max-complexity = 13

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,7 @@ repos:
     rev: 7.0.0
     hooks:
       - id: flake8
+        args: [--max-complexity=13]
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:


### PR DESCRIPTION
## Summary
- enforce max complexity with flake8
- ensure flake8 hook checks cyclomatic complexity

## Testing
- `pre-commit run --files .flake8 .pre-commit-config.yaml` *(fails: pre-commit not installed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6848b88523088323a862bb06d6ebbc26