### PR TITLE
Add back navigation to log list

### DIFF
--- a/frontend/src/components/QuestionLogList.jsx
+++ b/frontend/src/components/QuestionLogList.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
 import {
   Typography,
   Button,
@@ -18,11 +18,12 @@ import {
   InputLabel,
   FormControl,
 } from '@mui/material';
-import { Delete, Edit, Add } from '@mui/icons-material';
+import { Delete, Edit, Add, ArrowBack } from '@mui/icons-material';
 import api from '../api';
 
 function QuestionLogList() {
   const { questionId } = useParams();
+  const navigate = useNavigate();
   const [logs, setLogs] = useState([]);
   const [questions, setQuestions] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -110,6 +111,7 @@ function QuestionLogList() {
 
   return (
     <div>
+      <Button startIcon={<ArrowBack />} onClick={() => navigate('/')} sx={{ mb: 2 }}>Back to Questions</Button>
       <Typography variant="h4" gutterBottom>Attempts / Logs {questionTitle && `for "${questionTitle}"`}</Typography>
       <Button variant="contained" startIcon={<Add />} onClick={() => handleOpen()} sx={{ mb: 2 }}>Add Log</Button>
       {loading ? <CircularProgress /> : (

--- a/frontend/src/components/__tests__/QuestionLogList.test.jsx
+++ b/frontend/src/components/__tests__/QuestionLogList.test.jsx
@@ -12,6 +12,7 @@ vi.mock('react-router-dom', async () => {
   return {
     ...actual,
     useParams: () => ({ questionId: '1' }),
+    useNavigate: () => vi.fn(),
   };
 });
 


### PR DESCRIPTION
## Summary
- add a Back to Questions button to `QuestionLogList`
- import `useNavigate` & `ArrowBack` to support navigation
- update tests to mock `useNavigate`

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685edb985bec83239d8f4c0f201db679