### PR TITLE
Make QuestionList responsive

### DIFF
--- a/frontend/src/components/QuestionList.jsx
+++ b/frontend/src/components/QuestionList.jsx
@@ -166,7 +166,14 @@ function QuestionList() {
       {error && (
         <Typography color="error" sx={{ mb: 2, ml: 1 }}>{error}</Typography>
       )}
-      <Box sx={{ width: '50vw', maxWidth: '50vw', ml: 1, boxSizing: 'border-box' }}>
+      <Box
+        sx={{
+          width: { xs: '100%', sm: '50vw' },
+          maxWidth: { xs: '100%', sm: '50vw' },
+          ml: 1,
+          boxSizing: 'border-box',
+        }}
+      >
         {renderQuestionsList()}
       </Box>
       {/* Question CRUD Dialog */}


### PR DESCRIPTION
## Summary
- make QuestionList `<Box>` responsive so the list uses full width on small devices

## Testing
- `npm test` *(fails: vitest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685edb96b2f48323a9c8e7d22b7d0da4