### PR TITLE
Add aria label for question log link

### DIFF
--- a/frontend/src/components/QuestionListItem.jsx
+++ b/frontend/src/components/QuestionListItem.jsx
@@ -16,7 +16,8 @@ function QuestionListItem({ question, onEdit, onDelete, onViewLogs }) {
         <ListItemText
           primary={<Box>
             <span
-              role="button"
+              role="link"
+              aria-label={`View logs for ${question.title}`}
               tabIndex={0}
               style={{ cursor: 'pointer', fontWeight: 700, outline: 'none' }}
               onClick={() => onViewLogs(question.id)}

--- a/frontend/src/components/__tests__/QuestionListItem.test.jsx
+++ b/frontend/src/components/__tests__/QuestionListItem.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import QuestionListItem from '../QuestionListItem.jsx';
+import { vi } from 'vitest';
+
+const question = {
+  id: 1,
+  title: 'Sample Question',
+  notes: '',
+  difficulty: 'Easy',
+  tags: [],
+};
+
+test('title span acts as link to view logs', async () => {
+  const onViewLogs = vi.fn();
+  render(
+    <QuestionListItem
+      question={question}
+      onEdit={vi.fn()}
+      onDelete={vi.fn()}
+      onViewLogs={onViewLogs}
+    />
+  );
+
+  const link = screen.getByRole('link', {
+    name: `View logs for ${question.title}`,
+  });
+  expect(link).toBeInTheDocument();
+
+  link.focus();
+  await userEvent.keyboard('{Enter}');
+  expect(onViewLogs).toHaveBeenCalledWith(question.id);
+});


### PR DESCRIPTION
## Summary
- mark question titles with role='link' and aria-label
- test QuestionListItem accessible link behavior

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `pytest -q` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685edb9af7a88323b59cb32279808ed2