### PR TITLE
Default question log date to current time

### DIFF
--- a/frontend/src/components/QuestionLogList.jsx
+++ b/frontend/src/components/QuestionLogList.jsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import { Delete, Edit, Add } from '@mui/icons-material';
 import api from '../api';
+import { getCurrentDateTimeLocalString } from '../utils';
 
 function QuestionLogList() {
   const { questionId } = useParams();
@@ -30,7 +31,7 @@ function QuestionLogList() {
   const [editLog, setEditLog] = useState(null);
   const [form, setForm] = useState({
     question: questionId || '',
-    date_attempted: '',
+    date_attempted: getCurrentDateTimeLocalString(),
     time_spent_min: '',
     outcome: '',
     solution_approach: '',
@@ -65,19 +66,35 @@ function QuestionLogList() {
 
   const handleOpen = (log = null) => {
     setEditLog(log);
-    setForm(log ? {
-      ...log,
-      question: log.question.id,
-    } : {
-      question: questionId || '', date_attempted: '', time_spent_min: '', outcome: '', solution_approach: '', self_notes: '',
-    });
+    setForm(
+      log
+        ? {
+            ...log,
+            question: log.question.id,
+          }
+        : {
+            question: questionId || '',
+            date_attempted: getCurrentDateTimeLocalString(),
+            time_spent_min: '',
+            outcome: '',
+            solution_approach: '',
+            self_notes: '',
+          },
+    );
     setOpen(true);
   };
 
   const handleClose = () => {
     setOpen(false);
     setEditLog(null);
-    setForm({ question: questionId || '', date_attempted: '', time_spent_min: '', outcome: '', solution_approach: '', self_notes: '' });
+    setForm({
+      question: questionId || '',
+      date_attempted: getCurrentDateTimeLocalString(),
+      time_spent_min: '',
+      outcome: '',
+      solution_approach: '',
+      self_notes: '',
+    });
   };
 
   const handleChange = (e) => {

--- a/frontend/src/components/__tests__/QuestionLogList.test.jsx
+++ b/frontend/src/components/__tests__/QuestionLogList.test.jsx
@@ -36,3 +36,20 @@ test('fetches and displays question logs', async () => {
   expect(await screen.findByText('Question1')).toBeInTheDocument();
   expect(await screen.findByText('Outcome: Solved')).toBeInTheDocument();
 });
+
+test('defaults date to today when opening add log dialog', async () => {
+  api.get.mockResolvedValueOnce({ data: [] });
+  api.get.mockResolvedValueOnce({ data: [{ id: 1, title: 'Question1' }] });
+
+  render(<QuestionLogList />);
+
+  // Open the add log dialog
+  screen.getByText('Add Log').click();
+
+  const dateInput = await screen.findByLabelText('Date Attempted');
+  const today = new Date();
+  const local = new Date(today.getTime() - today.getTimezoneOffset() * 60000)
+    .toISOString()
+    .slice(0, 10);
+  expect(dateInput.value).toContain(local);
+});

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -15,3 +15,11 @@ export function getCookie(name) {
     }
     return cookieValue;
 }
+
+// Returns current date/time formatted for an HTML datetime-local input
+export function getCurrentDateTimeLocalString() {
+    const now = new Date();
+    const offsetMs = now.getTimezoneOffset() * 60000;
+    const local = new Date(now.getTime() - offsetMs);
+    return local.toISOString().slice(0, 16);
+}


### PR DESCRIPTION
## Summary
- autofill date attempted with the current time when opening a new log form
- reset date field to current time when closing the dialog
- expose helper `getCurrentDateTimeLocalString`
- test date default behavior

## Testing
- `npm --prefix frontend test` *(fails: vitest not found)*
- `pytest --cov=backend --cov-report=term-missing` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685edcc884b88323b5fc125c9abe4154