### PR TITLE
Add Sentry monitoring setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ This project is a full-stack application for managing programming interview ques
   - Install dependencies with `npm install`.
   - Start the development server with `npm run dev`.
 
+## Monitoring with Sentry
+
+To enable Sentry monitoring, create Sentry projects for both the backend and the
+frontend and set the following environment variables:
+
+- `BACKEND_SENTRY_DSN` for the Django backend
+- `VITE_FRONTEND_SENTRY_DSN` for the React frontend
+
+With these variables set, both applications will send errors and performance
+data to Sentry.
+
 ## Documentation
 
 - Backend architecture: [`docs/backend_design.md`](docs/backend_design.md)

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -13,6 +13,9 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 from pathlib import Path
 import os
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent
 
@@ -161,3 +164,13 @@ CORS_ALLOWED_ORIGINS = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
 ]
+
+# Sentry configuration
+BACKEND_SENTRY_DSN = os.environ.get("BACKEND_SENTRY_DSN")
+if BACKEND_SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=BACKEND_SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        traces_sample_rate=float(os.environ.get("SENTRY_TRACES_SAMPLE_RATE", 0.0)),
+        send_default_pii=True,
+    )

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
     "axios": "^1.9.0",
+    "@sentry/react": "^7.95.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.2"

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,15 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import * as Sentry from '@sentry/react'
+import { BrowserTracing } from '@sentry/react'
 import './index.css'
 import App from './App.jsx'
+
+Sentry.init({
+  dsn: import.meta.env.VITE_FRONTEND_SENTRY_DSN,
+  integrations: [new BrowserTracing()],
+  tracesSampleRate: 1.0,
+})
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
 django
 djangorestframework
 requests
+sentry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ asgiref==3.8.1
 Django==5.2.1
 djangorestframework==3.16.0
 requests==2.32.3
+sentry-sdk==2.2.0


### PR DESCRIPTION
## Summary
- BACKEND: integrate `sentry-sdk` with environment variable `BACKEND_SENTRY_DSN`
- FRONTEND: set up `@sentry/react` with `VITE_FRONTEND_SENTRY_DSN`
- update README instructions

## Testing
- `pre-commit run --files README.md backend/settings.py frontend/package.json frontend/src/main.jsx requirements.in requirements.txt` *(fails: command not found)*
- `flake8 backend/settings.py frontend/src/main.jsx README.md` *(fails: command not found)*
- `black backend/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*


------
https://chatgpt.com/codex/tasks/task_e_6848b85ddd908323ba818530d80271b4